### PR TITLE
Race condition results in update()'s initial raf to be thrown away

### DIFF
--- a/src/Scrollbars.js
+++ b/src/Scrollbars.js
@@ -147,7 +147,7 @@ export default createClass({
         });
     },
 
-    update() {
+    update(callback) {
         if (getScrollbarWidth() === 0) return;
         this.raf(() => {
             const {
@@ -155,7 +155,7 @@ export default createClass({
                 heightPercentageInner
             } = this.getInnerSizePercentage();
 
-            const { x, y } = this.getPosition();
+            const { x, y, ...values } = this.getPosition();
 
             this.setScrollbarHorizontalStyle(
                 this.getScrollbarHorizontalStyle(widthPercentageInner)
@@ -169,26 +169,17 @@ export default createClass({
             this.setThumbVerticalStyle(
                 this.getThumbVerticalStyle(y, heightPercentageInner)
             );
+
+            if (typeof callback === 'function') {
+              callback(x, y, values);
+            }
         });
     },
 
     handleScroll(event) {
         const { onScroll } = this.props;
-        this.raf(() => {
-            const { x, y, ...values } = this.getPosition();
-            const {
-                widthPercentageInner,
-                heightPercentageInner
-            } = this.getInnerSizePercentage();
-
-            if (onScroll) onScroll(event, values);
-
-            this.setThumbHorizontalStyle(
-                this.getThumbHorizontalStyle(x, widthPercentageInner)
-            );
-            this.setThumbVerticalStyle(
-                this.getThumbVerticalStyle(y, heightPercentageInner)
-            );
+        this.update((x, y, values) => {
+          if (onScroll) onScroll(event, values);
         });
     },
 


### PR DESCRIPTION
Hi!

Thanks for the great component!

My use-case involves the parent component to scroll the scrollbars to some position (specific row in a table), so I calculate the position and scroll on ``componentDidMount``, like this:

```
componentDidMount() {
...
   this.refs.scrollbars.scrollTop(this.refs.tableBodyTbody.children[0].offsetHeight * rowIndex);
...
}
```

There seems to be race condition, when ``handleScroll()`` can be called in the same time initial ``update()`` is called, ``handleScroll``'s RAF may cancel ``update``'s RAF which will result in the ``setScrollbarVerticalStyle()`` and ``setScrollbarHorizontalStyle()`` not to be called.

My suggested solution in this PR is unifying the update styles function(s) from ``handleScroll()`` and update.