### PR TITLE
add scrollbarWidth property

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ class App extends Component {
 * `renderThumbHorizontal`: (Function) Horizontal thumb element
 * `renderThumbVertical`: (Function) Vertical thumb element
 * `renderView`: (Function) The element your content will be rendered in
+* * **Additional properties**
+* `scrollbarWidth`: (Number) Specify custom scrollbarWidth
 
 **Don't forget to pass the received props to your custom element. Example:**
 

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -37,6 +37,7 @@ export default createClass({
         renderView: PropTypes.func,
         style: PropTypes.object,
         children: PropTypes.node,
+        scrollbarWidth: PropTypes.number
     },
 
     getDefaultProps() {
@@ -127,8 +128,14 @@ export default createClass({
         };
     },
 
+    getInnerScrollbarWidth() {
+        return typeof this.props.scrollbarWidth !== 'undefined'
+            ? this.props.scrollbarWidth
+            : getScrollbarWidth();
+    },
+
     validate() {
-        if (!getScrollbarWidth()) return;
+        if (!this.getInnerScrollbarWidth()) return;
         const root = findDOMNode(this);
         const { barHorizontal, barVertical } = this.refs;
         const { clientHeight: rootClientHeight } = root;
@@ -313,9 +320,10 @@ export default createClass({
         } = this.getInnerSizePercentage();
 
         const { x, y, ...values } = this.getPosition();
+        const scrollbarWidth = this.getInnerScrollbarWidth();
 
         this.raf(() => {
-            if (getScrollbarWidth() > 0) {
+            if (scrollbarWidth > 0) {
                 const thumbHorizontalStyle = {
                     width: (widthPercentageInner < 100) ? (widthPercentageInner + '%') : 0,
                     transform: 'translateX(' + x + '%)'
@@ -333,7 +341,7 @@ export default createClass({
     },
 
     render() {
-        const scrollbarWidth = getScrollbarWidth();
+        const scrollbarWidth = this.getInnerScrollbarWidth();
         const {
             style,
             renderScrollbarHorizontal,


### PR DESCRIPTION
Hello! Thanks for the awesome library.

I have a small issue: I can't create custom scroll in OSX environment, because `getScrollbarWidth` function always returns `0`. It's absolutely valid, because mac scrolls really don't have width, but I want some prop to make the library work anyway.

So I added `scrollbarWidth` property which can be used to override default behavior. What do you think?