### PR TITLE
Change peer dependency semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "webpack-dev-server": "^1.8.2"
   },
   "peerDependencies": {
-    "react": "^0.14.5",
-    "react-dom": "^0.14.5"
+    "react": "~0.14.5",
+    "react-dom": "~0.14.5"
   },
   "dependencies": {
     "dom-css": "^2.0.0",


### PR DESCRIPTION
I believe the caret does not do what you're expecting here. It does not allow React 0.14.6 or 0.14.7. But the tilde should (https://nodesource.com/blog/semver-tilde-and-caret/). Or I think you could use `>=`. Either way.