### PR TITLE
API methods description update

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -48,10 +48,10 @@
 * `scrollToBottom()`: scroll to bottom
 * `scrollToLeft()`: scroll to left
 * `scrollToRight()`: scroll to right
-* `getScrollLeft`: get scrollLeft value
-* `getScrollTop`: get scrollTop value
-* `getScrollWidth`: get scrollWidth value
-* `getScrollHeight`: get scrollHeight value
-* `getWidth`: get view client width
-* `getHeight`: get view client height
-* `getValues`: get an object with values about the current position.
+* `getScrollLeft()`: get scrollLeft value
+* `getScrollTop()`: get scrollTop value
+* `getScrollWidth()`: get scrollWidth value
+* `getScrollHeight()`: get scrollHeight value
+* `getClientWidth()`: get view client width
+* `getClientHeight()`: get view client height
+* `getValues()`: get an object with values about the current position.


### PR DESCRIPTION
* getWidth -> getClientWidth()
* getHeight -> getClientHeight()
* Add parentheses to all `get*` methods to make it clear, that it's a method and not getter expression