### PR TITLE
use default style when using customization feature.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-custom-scrollbars",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "React scrollbars component",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Scrollbars/styles.js
+++ b/src/Scrollbars/styles.js
@@ -37,24 +37,38 @@ export const viewStyleUniversalInitial = {
 
 export const trackHorizontalStyleDefault = {
     position: 'absolute',
-    height: 6
+    height: 6,
+    right: 2,
+    bottom: 2,
+    left: 2,
+    borderRadius: 3
 };
 
 export const trackVerticalStyleDefault = {
     position: 'absolute',
-    width: 6
+    width: 6,
+    right: 2,
+    bottom: 2,
+    top: 2,
+    borderRadius: 3
 };
 
 export const thumbHorizontalStyleDefault = {
     position: 'relative',
     display: 'block',
-    height: '100%'
+    height: '100%',
+    cursor: 'pointer',
+    borderRadius: 'inherit',
+    backgroundColor: 'rgba(0,0,0,.2)'
 };
 
 export const thumbVerticalStyleDefault = {
     position: 'relative',
     display: 'block',
-    width: '100%'
+    width: '100%',
+    cursor: 'pointer',
+    borderRadius: 'inherit',
+    backgroundColor: 'rgba(0,0,0,.2)'
 };
 
 export const disableSelectStyle = {

--- a/test/Scrollbars/rendering.js
+++ b/test/Scrollbars/rendering.js
@@ -206,19 +206,21 @@ export default function createTests(scrollbarWidth) {
                     it('should render same style with default track', done => {
                         render((
                             <div>
-                                <Scrollbars className="sc"
-                                  style={{width: 100, height: 100}}>
+                                <Scrollbars
+                                  className="sc"
+                                  style={{ width: 100, height: 100 }}>
                                     <div style={{ width: 200, height: 200 }}/>
                                 </Scrollbars>
-                                <Scrollbars className="sc"
+                                <Scrollbars
+                                  className="sc"
                                   renderTrackVertical={p => <div {...p} />}
-                                  style={{width: 100, height: 100}}>
+                                  style={{ width: 100, height: 100 }}>
                                     <div style={{ width: 200, height: 200 }}/>
                                 </Scrollbars>
                             </div>
                         ), node, function callback() {
-                            const node = findDOMNode(this);
-                            const vTracks = node.querySelectorAll('.sc > div:last-child');
+                            const root = findDOMNode(this);
+                            const vTracks = root.querySelectorAll('.sc > div:last-child');
 
                             const attr1 = vTracks[0].getAttribute('style');
                             const attr2 = vTracks[1].getAttribute('style');
@@ -231,9 +233,9 @@ export default function createTests(scrollbarWidth) {
                     it('should override default style.', done => {
                         render((
                             <Scrollbars
-                                renderTrackHorizontal={({style, ...props}) => {
-                                  return <div {...props} style={{...style, right: 4}} />;
-                                }}>
+                                renderTrackHorizontal={({ style, ...props }) =>
+                                  <div {...props} style={{ ...style, right: 4 }} />
+                                }>
                                 <div style={{ width: 200, height: 200 }}/>
                             </Scrollbars>
                         ), node, function callback() {

--- a/test/Scrollbars/rendering.js
+++ b/test/Scrollbars/rendering.js
@@ -224,7 +224,6 @@ export default function createTests(scrollbarWidth) {
                             const attr2 = vTracks[1].getAttribute('style');
 
                             expect(attr1).toBe(attr2);
-
                             done();
                         });
                     });

--- a/test/Scrollbars/rendering.js
+++ b/test/Scrollbars/rendering.js
@@ -202,6 +202,46 @@ export default function createTests(scrollbarWidth) {
                             done();
                         });
                     });
+
+                    it('should render same style with default track', done => {
+                        render((
+                            <div>
+                                <Scrollbars className="sc"
+                                  style={{width: 100, height: 100}}>
+                                    <div style={{ width: 200, height: 200 }}/>
+                                </Scrollbars>
+                                <Scrollbars className="sc"
+                                  renderTrackVertical={p => <div {...p} />}
+                                  style={{width: 100, height: 100}}>
+                                    <div style={{ width: 200, height: 200 }}/>
+                                </Scrollbars>
+                            </div>
+                        ), node, function callback() {
+                            const node = findDOMNode(this);
+                            const vTracks = node.querySelectorAll('.sc > div:last-child');
+
+                            const attr1 = vTracks[0].getAttribute('style');
+                            const attr2 = vTracks[1].getAttribute('style');
+
+                            expect(attr1).toBe(attr2);
+
+                            done();
+                        });
+                    });
+
+                    it('should override default style.', done => {
+                        render((
+                            <Scrollbars
+                                renderTrackHorizontal={({style, ...props}) => {
+                                  return <div {...props} style={{...style, right: 4}} />;
+                                }}>
+                                <div style={{ width: 200, height: 200 }}/>
+                            </Scrollbars>
+                        ), node, function callback() {
+                            expect(this.refs.trackHorizontal.style.right).toBe('4px');
+                            done();
+                        });
+                    });
                 });
 
                 describe('when custom `renderThumbHorizontal` is passed', () => {


### PR DESCRIPTION
There is no visible track or thumb when using `renderTrack*` `renderThumb*` option like below demo codes.

``` jsx
<Scrollbars renderTrackVertical={p => <div {...p} />} />
```

Because it isn't adding default style without user customization styles. (It seems to be bug..)

So i need additional styles for every customization code like this.

``` jsx
<Scrollbars renderTrackVertical={p =>
  <div {...p, style: {width, right, bottom, top}} />
} />
```

If you think this PR is not right, the `customization` document must be contain this issue at least.

Thank you :)
