### PR TITLE
Added missing parameter

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -311,7 +311,7 @@ export default createClass({
         this.update();
     },
 
-    handleHorizontalTrackMouseDown() {
+    handleHorizontalTrackMouseDown(event) {
         const { view } = this.refs;
         const { target, clientX } = event;
         const { left: targetLeft } = target.getBoundingClientRect();


### PR DESCRIPTION
Fixes event not defined error in Firefox when clicking the horizontal track (https://github.com/malte-wessel/react-custom-scrollbars/issues/76).