### PR TITLE
Add preventDefault to mouse down events

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -312,6 +312,7 @@ export default createClass({
     },
 
     handleHorizontalTrackMouseDown(event) {
+        event.preventDefault();
         const { view } = this.refs;
         const { target, clientX } = event;
         const { left: targetLeft } = target.getBoundingClientRect();
@@ -321,6 +322,7 @@ export default createClass({
     },
 
     handleVerticalTrackMouseDown(event) {
+        event.preventDefault();
         const { view } = this.refs;
         const { target, clientY } = event;
         const { top: targetTop } = target.getBoundingClientRect();
@@ -330,6 +332,7 @@ export default createClass({
     },
 
     handleHorizontalThumbMouseDown(event) {
+        event.preventDefault();
         this.handleDragStart(event);
         const { target, clientX } = event;
         const { offsetWidth } = target;
@@ -338,6 +341,7 @@ export default createClass({
     },
 
     handleVerticalThumbMouseDown(event) {
+        event.preventDefault();
         this.handleDragStart(event);
         const { target, clientY } = event;
         const { offsetHeight } = target;


### PR DESCRIPTION
I depend on some other packages that lose focus (blur) on some mouse down events. This prevents losing that focus by `preventDefault()` on the `mouse down` events.