### PR TITLE
Add ability to set custom styles for view

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -62,6 +62,7 @@ export default createClass({
         ]),
         universal: PropTypes.bool,
         style: PropTypes.object,
+        viewStyle: PropTypes.object,
         children: PropTypes.node,
     },
 
@@ -82,6 +83,7 @@ export default createClass({
             autoHeightMin: 0,
             autoHeightMax: 200,
             universal: false,
+            viewStyle: {},
         };
     },
 
@@ -539,6 +541,7 @@ export default createClass({
             autoHeightMin,
             autoHeightMax,
             style,
+            viewStyle,
             children,
             ...props
         } = this.props;
@@ -577,7 +580,9 @@ export default createClass({
                 maxHeight: autoHeightMax
             }),
             // Override
-            ...((universal && !didMountUniversal) && viewStyleUniversalInitial)
+            ...((universal && !didMountUniversal) && viewStyleUniversalInitial),
+            // Override with custom styles
+            ...viewStyle
         };
 
         const trackAutoHeightStyle = {


### PR DESCRIPTION
Hi! I am using react-custom-scrollbars in list with sticky headers, and need to use view with static position. So, i set style through view ref on my componentDidMount (position: static, height: 100%, overflow: auto), but it looks hacky.