### PR TITLE
Add iFrame support and cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "clean": "rimraf lib dist",
     "build": "babel src --out-dir lib",
-    "build:umd": "NODE_ENV=development webpack src/index.js dist/react-custom-scrollbars.js",
-    "build:umd:min": "NODE_ENV=production webpack src/index.js dist/react-custom-scrollbars.min.js",
+    "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/react-custom-scrollbars.js",
+    "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/react-custom-scrollbars.min.js",
     "lint": "eslint src test examples",
-    "test": "NODE_ENV=test karma start",
-    "test:watch": "NODE_ENV=test karma start --auto-watch --no-single-run",
-    "test:cov": "NODE_ENV=test COVERAGE=true karma start --single-run",
+    "test": "cross-env NODE_ENV=test karma start",
+    "test:watch": "cross-env NODE_ENV=test karma start --auto-watch --no-single-run",
+    "test:cov": "cross-env NODE_ENV=test COVERAGE=true karma start --single-run",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build && npm run build:umd && npm run build:umd:min && node ./prepublish"
   },
   "repository": {
@@ -42,6 +42,7 @@
     "babel-preset-stage-1": "^6.1.18",
     "babel-register": "^6.3.13",
     "babel-runtime": "^6.3.19",
+    "cross-env": "^3.1.4",
     "es3ify": "^0.2.1",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^9.0.1",

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -1,6 +1,8 @@
 import raf, { cancel as caf } from 'raf';
 import css from 'dom-css';
 import { createClass, createElement, PropTypes, cloneElement } from 'react';
+import {findDOMNode} from 'react-dom'
+
 import isString from '../utils/isString';
 import getScrollbarWidth from '../utils/getScrollbarWidth';
 import returnFalse from '../utils/returnFalse';
@@ -92,6 +94,7 @@ export default createClass({
     },
 
     componentDidMount() {
+        this.ownerDocument = findDOMNode(this).ownerDocument;
         this.addListeners();
         this.update();
         this.componentDidMountUniversal();
@@ -347,16 +350,20 @@ export default createClass({
 
     setupDragging() {
         css(document.body, disableSelectStyle);
-        document.addEventListener('mousemove', this.handleDrag);
-        document.addEventListener('mouseup', this.handleDragEnd);
-        document.onselectstart = returnFalse;
+        if(this.ownerDocument) {
+          this.ownerDocument.addEventListener('mousemove', this.handleDrag);
+          this.ownerDocument.addEventListener('mouseup', this.handleDragEnd);
+          this.ownerDocument.onselectstart = returnFalse;
+        }
     },
 
     teardownDragging() {
         css(document.body, disableSelectStyleReset);
-        document.removeEventListener('mousemove', this.handleDrag);
-        document.removeEventListener('mouseup', this.handleDragEnd);
-        document.onselectstart = undefined;
+        if(this.ownerDocument) {
+          this.ownerDocument.removeEventListener('mousemove', this.handleDrag);
+          this.ownerDocument.removeEventListener('mouseup', this.handleDragEnd);
+          this.ownerDocument.onselectstart = undefined;
+        }
     },
 
     handleDragStart(event) {


### PR DESCRIPTION
When used in an iFrame event listeners have to be added to element's ownerDocument (instead of global ducument variable)
Cross-env adds support for setting NODE_ENV on windows