### PR TITLE
props to call functions on an edge reached

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@
 * `onScroll`: (Function) Event handler
   * Signature: `onScroll(event)`
 * `onScrollFrame`: (Function) Runs inside the animation frame.
-  * Signature: `onScroll(values)`
+  * Signature: `onScrollFrame(values)`
   * `values`: (Object) Values about the current position
     * `values.top`: (Number) scrollTop progess, from 0 to 1
     * `values.left`: (Number) scrollLeft progess, from 0 to 1
@@ -17,6 +17,10 @@
     * `values.scrollHeight`: (Number) Native scrollHeight
     * `values.scrollLeft`: (Number) Native scrollLeft
     * `values.scrollTop`: (Number) Native scrollTop
+* `onScrollAtTop` (Function) Called on scroll event if scroll is at top edge
+* `onScrollAtBottom` (Function) Called on scroll event if scroll is at bottom edge
+* `onScrollAtRight` (Function) Called on scroll event if scroll is at left edge
+* `onScrollAtLeft` (Function) Called on scroll event if scroll is at right edge
 * `onScrollStart` (Function) Called when scrolling starts
 * `onScrollStop` (Function) Called when scrolling stops
 * `onUpdate` (Function) Called when ever the component is updated. Runs inside the animation frame
@@ -27,6 +31,8 @@
 * `renderThumbHorizontal`: (Function) Horizontal thumb element
 * `renderThumbVertical`: (Function) Vertical thumb element
 * `hideTracksWhenNotNeeded`: (Boolean) Hide tracks (`visibility: hidden`) when content does not overflow container. (default: false)
+* `edgeXThreshold`: (Number) Set a threshold for `onScrollAtRight` and `onScrollAtLeft` methods
+* `edgeYThreshold`: (Number) Set a threshold for `onScrollAtTop` and `onScrollAtBottom` methods
 * `thumbSize`: (Number) Set a fixed size for thumbs in px.
 * `thumbMinSize`: (Number) Minimal thumb size in px. (default: 30)
 * `autoHide`: (Boolean) Enable auto-hide mode (default: `false`)

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -36,6 +36,10 @@ export default createClass({
     propTypes: {
         onScroll: PropTypes.func,
         onScrollFrame: PropTypes.func,
+        onScrollAtTop: PropTypes.func,
+        onScrollAtBottom: PropTypes.func,
+        onScrollAtLeft: PropTypes.func,
+        onScrollAtRight: PropTypes.func,
         onScrollStart: PropTypes.func,
         onScrollStop: PropTypes.func,
         onUpdate: PropTypes.func,
@@ -45,6 +49,8 @@ export default createClass({
         renderThumbHorizontal: PropTypes.func,
         renderThumbVertical: PropTypes.func,
         tagName: PropTypes.string,
+        edgeXThreshold: PropTypes.number,
+        edgeYThreshold: PropTypes.number,
         thumbSize: PropTypes.number,
         thumbMinSize: PropTypes.number,
         hideTracksWhenNotNeeded: PropTypes.bool,
@@ -73,6 +79,8 @@ export default createClass({
             renderThumbHorizontal: renderThumbHorizontalDefault,
             renderThumbVertical: renderThumbVerticalDefault,
             tagName: 'div',
+            edgeXThreshold: 30,
+            edgeYThreshold: 30,
             thumbMinSize: 30,
             hideTracksWhenNotNeeded: false,
             autoHide: false,
@@ -154,10 +162,18 @@ export default createClass({
             clientWidth,
             clientHeight
         } = view;
+        const {
+            edgeXThreshold, 
+            edgeYThreshold
+        } = this.props;
 
         return {
             left: (scrollLeft / (scrollWidth - clientWidth)) || 0,
             top: (scrollTop / (scrollHeight - clientHeight)) || 0,
+            atLeft: (scrollLeft < edgeXThreshold),
+            atRight: (scrollWidth - clientWidth - scrollLeft < edgeXThreshold),
+            atTop: (scrollTop < edgeYThreshold), 
+            atBottom: (scrollHeight - clientHeight - scrollTop < edgeYThreshold),
             scrollLeft,
             scrollTop,
             scrollWidth,
@@ -272,12 +288,22 @@ export default createClass({
     },
 
     handleScroll(event) {
-        const { onScroll, onScrollFrame } = this.props;
+        const { onScroll, onScrollFrame,
+                onScrollAtTop, onScrollAtBottom,
+                onScrollAtLeft, onScrollAtRight 
+        } = this.props;
         if (onScroll) onScroll(event);
         this.update(values => {
-            const { scrollLeft, scrollTop } = values;
+            const { scrollLeft, scrollTop, 
+                    atTop, atBottom,
+                    atLeft, atRight
+            } = values;
             this.viewScrollLeft = scrollLeft;
             this.viewScrollTop = scrollTop;
+            if (onScrollAtTop && atTop) onScrollAtTop();
+            if (onScrollAtBottom && atBottom) onScrollAtBottom();
+            if (onScrollAtLeft && atLeft) onScrollAtLeft();
+            if (onScrollAtRight && atRight) onScrollAtRight();
             if (onScrollFrame) onScrollFrame(values);
         });
         this.detectScrolling();
@@ -519,6 +545,10 @@ export default createClass({
         const {
             onScroll,
             onScrollFrame,
+            onScrollAtLeft,
+            onScrollAtRight,
+            onScrollAtTop,
+            onScrollAtBottom,
             onScrollStart,
             onScrollStop,
             onUpdate,
@@ -528,6 +558,8 @@ export default createClass({
             renderThumbHorizontal,
             renderThumbVertical,
             tagName,
+            edgeXThreshold,
+            edgeYThreshold,
             hideTracksWhenNotNeeded,
             autoHide,
             autoHideTimeout,


### PR DESCRIPTION
Hello.

This is a patch intended to make everyone’s life a little bit easier: it allow a user to set up a callback for 'at edge' events.
If a scroller is 'threshold' pixels close to an edge a call back will be called with each scroll event.
There are two different thresholds: for X and Y axis and four distinct callbacks: left, right, top and bottom.

I understand that you can archive this with calculating required values in the `onScrollFrame` but it's easier to use exact callbacks.

Additionally, I fixed a typo in the doc... 

There is an obvious possible improvement: suppress multiple function calls on during a single edge approach. But it might be useful for someone to get handler called multiple times.

Feel free to ask questions and propose additional improvements,
with hope to be helpful,
Me =)