### PR TITLE
Add thumb dragging func props

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -294,6 +294,8 @@ export default class Scrollbars extends Component {
 
     handleHorizontalThumbMouseDown(event) {
         event.preventDefault();
+        const { onDragStartHorizontal } = this.props;
+        if (onDragStartHorizontal) onDragStartHorizontal();
         this.handleDragStart(event);
         const { target, clientX } = event;
         const { offsetWidth } = target;
@@ -303,6 +305,8 @@ export default class Scrollbars extends Component {
 
     handleVerticalThumbMouseDown(event) {
         event.preventDefault();
+        const { onDragStartVertical } = this.props;
+        if (onDragStartVertical) onDragStartVertical();
         this.handleDragStart(event);
         const { target, clientY } = event;
         const { offsetHeight } = target;
@@ -353,6 +357,8 @@ export default class Scrollbars extends Component {
     }
 
     handleDragEnd() {
+        const { onDragEnd } = this.props;
+        if (onDragEnd) onDragEnd();
         this.dragging = false;
         this.prevPageX = this.prevPageY = 0;
         this.teardownDragging();
@@ -482,6 +488,9 @@ export default class Scrollbars extends Component {
             onScrollFrame,
             onScrollStart,
             onScrollStop,
+            onDragStartHorizontal,
+            onDragStartVertical,
+            onDragEnd,
             onUpdate,
             renderView,
             renderTrackHorizontal,
@@ -593,6 +602,9 @@ Scrollbars.propTypes = {
     onScrollFrame: PropTypes.func,
     onScrollStart: PropTypes.func,
     onScrollStop: PropTypes.func,
+    onDragStartHorizontal: PropTypes.func,
+    onDragStartVertical: PropTypes.func,
+    onDragEnd: PropTypes.func,
     onUpdate: PropTypes.func,
     renderView: PropTypes.func,
     renderTrackHorizontal: PropTypes.func,

--- a/test/Scrollbars/dragThumb.js
+++ b/test/Scrollbars/dragThumb.js
@@ -39,7 +39,52 @@ export default function createTests(scrollbarWidth) {
                 }, 100);
             });
         });
-
+        it('should call `onDragStartHorizontal` one time', done => {
+            const spy = createSpy();
+            render((
+                <Scrollbars style={{ width: 100, height: 100 }} onDragStartHorizontal={spy}>
+                    <div style={{ width: 200, height: 200 }}/>
+                </Scrollbars>
+            ), node, function callback() {
+                setTimeout(() => {
+                    const { thumbHorizontal: thumb } = this.refs;
+                    const { left } = thumb.getBoundingClientRect();
+                    simulant.fire(thumb, 'mousedown', {
+                        target: thumb,
+                        clientX: left + 1
+                    });
+                    simulant.fire(document, 'mousemove', {
+                        clientX: left + 100
+                    });
+                    simulant.fire(document, 'mouseup');
+                    expect(spy.calls.length).toEqual(1);
+                    done();
+                }, 100);
+            });
+        });
+        it('should call `onDragEnd` one time', done => {
+            const spy = createSpy();
+            render((
+                <Scrollbars style={{ width: 100, height: 100 }} onDragEnd={spy}>
+                    <div style={{ width: 200, height: 200 }}/>
+                </Scrollbars>
+            ), node, function callback() {
+                setTimeout(() => {
+                    const { thumbHorizontal: thumb } = this.refs;
+                    const { left } = thumb.getBoundingClientRect();
+                    simulant.fire(thumb, 'mousedown', {
+                        target: thumb,
+                        clientX: left + 1
+                    });
+                    simulant.fire(document, 'mousemove', {
+                        clientX: left + 100
+                    });
+                    simulant.fire(document, 'mouseup');
+                    expect(spy.calls.length).toEqual(1);
+                    done();
+                }, 100);
+            });
+        });
         it('should disable selection', done => {
             render((
                 <Scrollbars style={{ width: 100, height: 100 }}>
@@ -81,6 +126,52 @@ export default function createTests(scrollbarWidth) {
                     });
                     simulant.fire(document, 'mouseup');
                     expect(view.scrollTop).toEqual(100);
+                    done();
+                }, 100);
+            });
+        });
+        it('should call `onDragStartVertical` one time', done => {
+            const spy = createSpy();
+            render((
+                <Scrollbars style={{ width: 100, height: 100 }} onDragStartVertical={spy}>
+                    <div style={{ width: 200, height: 200 }}/>
+                </Scrollbars>
+            ), node, function callback() {
+                setTimeout(() => {
+                    const { thumbVertical: thumb } = this.refs;
+                    const { top } = thumb.getBoundingClientRect();
+                    simulant.fire(thumb, 'mousedown', {
+                        target: thumb,
+                        clientY: top + 1
+                    });
+                    simulant.fire(document, 'mousemove', {
+                        clientY: top + 100
+                    });
+                    simulant.fire(document, 'mouseup');
+                    expect(spy.calls.length).toEqual(1);
+                    done();
+                }, 100);
+            });
+        });
+        it('should call `onDragEnd` one time', done => {
+            const spy = createSpy();
+            render((
+                <Scrollbars style={{ width: 100, height: 100 }} onDragEnd={spy}>
+                    <div style={{ width: 200, height: 200 }}/>
+                </Scrollbars>
+            ), node, function callback() {
+                setTimeout(() => {
+                    const { thumbVertical: thumb } = this.refs;
+                    const { top } = thumb.getBoundingClientRect();
+                    simulant.fire(thumb, 'mousedown', {
+                        target: thumb,
+                        clientY: top + 1
+                    });
+                    simulant.fire(document, 'mousemove', {
+                        clientY: top + 100
+                    });
+                    simulant.fire(document, 'mouseup');
+                    expect(spy.calls.length).toEqual(1);
                     done();
                 }, 100);
             });


### PR DESCRIPTION
Adds the following props:
`onDragStartHorizontal` - When dragging horizontal thumbnail this func fires if supplied
`onDragStartVertical` - When dragging vertical thumbnail this func fires if supplied
`onDragEnd` - When dragging stops this func fires if supplied

I am currently using this to style thumb when dragging.

Also added some tests to show they fire.
This PR does not include builds.

Thanks!