### PR TITLE
Support snapshot testing

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -200,7 +200,7 @@ export default class Scrollbars extends Component {
 
     addListeners() {
         /* istanbul ignore if */
-        if (typeof document === 'undefined') return;
+        if (typeof document === 'undefined' || !this.view) return;
         const { view, trackHorizontal, trackVertical, thumbHorizontal, thumbVertical } = this;
         view.addEventListener('scroll', this.handleScroll);
         if (!getScrollbarWidth()) return;
@@ -217,7 +217,7 @@ export default class Scrollbars extends Component {
 
     removeListeners() {
         /* istanbul ignore if */
-        if (typeof document === 'undefined') return;
+        if (typeof document === 'undefined' || !this.view) return;
         const { view, trackHorizontal, trackVertical, thumbHorizontal, thumbVertical } = this;
         view.removeEventListener('scroll', this.handleScroll);
         if (!getScrollbarWidth()) return;


### PR DESCRIPTION
Currently, [jest snapshot testing](https://facebook.github.io/jest/docs/snapshot-testing.html) is not possible for components using `react-custom-scrollbars`. This is due to:

```
    expected JSX to match snapshot: Cannot read property 'addEventListener' of null
```

This pull request makes sure that event listeners are not attached when running within a snapshot test.