### PR TITLE
horizontal thumb appear when there is no need

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -151,7 +151,7 @@ export default class Scrollbars extends Component {
         const { scrollWidth, clientWidth } = this.view;
         const trackWidth = getInnerWidth(this.trackHorizontal);
         const width = Math.ceil(clientWidth / scrollWidth * trackWidth);
-		if (trackWidth === width || (trackWidth === 0 && isNaN(width))) return 0;
+	if (trackWidth === width || (trackWidth === 0 && isNaN(width))) return 0;
         if (thumbSize) return thumbSize;
         return Math.max(width, thumbMinSize);
     }

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -151,7 +151,7 @@ export default class Scrollbars extends Component {
         const { scrollWidth, clientWidth } = this.view;
         const trackWidth = getInnerWidth(this.trackHorizontal);
         const width = Math.ceil(clientWidth / scrollWidth * trackWidth);
-        if (trackWidth === width) return 0;
+		if (trackWidth === width || (trackWidth === 0 && isNaN(width))) return 0;
         if (thumbSize) return thumbSize;
         return Math.max(width, thumbMinSize);
     }


### PR DESCRIPTION
If clientWidth and scrollWidth are 0, then width is calculated as NaN, which will break next condition and thumb will appear for full width