### PR TITLE
Make universal rendering link go somewhere

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -38,7 +38,7 @@
 * `autoHeightMin`: (Number) Set a minimum height for auto-height mode (default: 0)
 * `autoHeightMax`: (Number) Set a maximum height for auto-height mode (default: 200)
 * `universal`: (Boolean) Enable universal rendering (default: `false`)
-    * [Learn how to use universal rendering](#link)
+    * [Learn how to use universal rendering](usage.md#universal-rendering)
 
 ### Methods
 


### PR DESCRIPTION
In the API docs, the `universal` property has a link after it that goes to `#link`, which is not a valid link. It looks like this was a default of someone's Markdown editor which was never overwritten.

This pull request updates it to go to the universal rendering section of the usage document, which is my best guess as to what was intended.