### PR TITLE
Ability to requery scrollbar width

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -66,6 +66,8 @@ export default class Scrollbars extends Component {
         this.handleDrag = this.handleDrag.bind(this);
         this.handleDragEnd = this.handleDragEnd.bind(this);
 
+        this.devicesHaveChanged = false;
+
         this.state = {
             didMountUniversal: false
         };
@@ -85,6 +87,14 @@ export default class Scrollbars extends Component {
 
     componentDidUpdate() {
         this.update();
+    }
+
+    devicesChanged() {
+        this.devicesHaveChanged = true;
+    }
+
+    handledDevicesChanged() {
+        this.devicesHaveChanged = false;
     }
 
     componentWillUnmount() {
@@ -215,7 +225,7 @@ export default class Scrollbars extends Component {
         if (typeof document === 'undefined' || !this.view) return;
         const { view, trackHorizontal, trackVertical, thumbHorizontal, thumbVertical } = this;
         view.addEventListener('scroll', this.handleScroll);
-        if (!getScrollbarWidth()) return;
+        if (!getScrollbarWidth(this.devicesHaveChanged)) return;
         trackHorizontal.addEventListener('mouseenter', this.handleTrackMouseEnter);
         trackHorizontal.addEventListener('mouseleave', this.handleTrackMouseLeave);
         trackHorizontal.addEventListener('mousedown', this.handleHorizontalTrackMouseDown);
@@ -232,7 +242,7 @@ export default class Scrollbars extends Component {
         if (typeof document === 'undefined' || !this.view) return;
         const { view, trackHorizontal, trackVertical, thumbHorizontal, thumbVertical } = this;
         view.removeEventListener('scroll', this.handleScroll);
-        if (!getScrollbarWidth()) return;
+        if (!getScrollbarWidth(this.devicesHaveChanged)) return;
         trackHorizontal.removeEventListener('mouseenter', this.handleTrackMouseEnter);
         trackHorizontal.removeEventListener('mouseleave', this.handleTrackMouseLeave);
         trackHorizontal.removeEventListener('mousedown', this.handleHorizontalTrackMouseDown);
@@ -446,7 +456,7 @@ export default class Scrollbars extends Component {
     _update(callback) {
         const { onUpdate, hideTracksWhenNotNeeded } = this.props;
         const values = this.getValues();
-        if (getScrollbarWidth()) {
+        if (getScrollbarWidth(this.devicesHaveChanged)) {
             const { scrollLeft, clientWidth, scrollWidth } = values;
             const trackHorizontalWidth = getInnerWidth(this.trackHorizontal);
             const thumbHorizontalWidth = this.getThumbHorizontalWidth();
@@ -476,13 +486,15 @@ export default class Scrollbars extends Component {
             css(this.thumbHorizontal, thumbHorizontalStyle);
             css(this.thumbVertical, thumbVerticalStyle);
         }
+        this.handledDevicesChanged();
         if (onUpdate) onUpdate(values);
         if (typeof callback !== 'function') return;
         callback(values);
     }
 
     render() {
-        const scrollbarWidth = getScrollbarWidth();
+        const scrollbarWidth = getScrollbarWidth(this.devicesHaveChanged);
+        this.handledDevicesChanged();
         /* eslint-disable no-unused-vars */
         const {
             onScroll,

--- a/src/utils/getScrollbarWidth.js
+++ b/src/utils/getScrollbarWidth.js
@@ -1,8 +1,8 @@
 import css from 'dom-css';
 let scrollbarWidth = false;
 
-export default function getScrollbarWidth() {
-    if (scrollbarWidth !== false) return scrollbarWidth;
+export default function getScrollbarWidth(devicesHaveChanged) {
+    if (scrollbarWidth !== false && !devicesHaveChanged) return scrollbarWidth;
     /* istanbul ignore else */
     if (typeof document !== 'undefined') {
         const div = document.createElement('div');


### PR DESCRIPTION
Noticed a bug when switching from a scrollwheel mouse to an Apple Magic Trackpad/Mouse. You can see the bug on the demo page. The width doesn't update to take into account the new scrollbar. The code right now expects the scrollbar width not to change, it caches it forever. As I'm sure you know, with scrollwheel mice on macOS, the scrollbar is always present; with Apple pointer devices, only the thumb is visible when scrolling.

This adds a function which will invalidate the scrollbar width cache and requery scrollbar width on next render. Right now, it is external to detect a device change and call this function.
