### PR TITLE
fix: native scroller is shown within RTL pages

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,6 +39,7 @@
 * `autoHeightMax`: (Number) Set a maximum height for auto-height mode (default: 200)
 * `universal`: (Boolean) Enable universal rendering (default: `false`)
     * [Learn how to use universal rendering](#link)
+* `rtl`: (Boolean) Support rtl language (default: `false`)
 
 ### Methods
 

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -15,6 +15,7 @@ import {
     viewStyleDefault,
     viewStyleAutoHeight,
     viewStyleUniversalInitial,
+    viewStyleRtlUniversalInitial,
     trackHorizontalStyleDefault,
     trackVerticalStyleDefault,
     thumbHorizontalStyleDefault,
@@ -549,7 +550,7 @@ export default class Scrollbars extends Component {
                 maxHeight: autoHeightMax
             }),
             // Override
-            ...((universal && !didMountUniversal) && viewStyleUniversalInitial)
+            ...((universal && !didMountUniversal) && (rtl ? viewStyleRtlUniversalInitial : viewStyleUniversalInitial))
         };
 
         const trackAutoHeightStyle = {

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -508,6 +508,7 @@ export default class Scrollbars extends Component {
             autoHeightMax,
             style,
             children,
+            rtl,
             ...props
         } = this.props;
         /* eslint-enable no-unused-vars */
@@ -527,7 +528,10 @@ export default class Scrollbars extends Component {
         const viewStyle = {
             ...viewStyleDefault,
             // Hide scrollbars by setting a negative margin
-            marginRight: scrollbarWidth ? -scrollbarWidth : 0,
+            ...(rtl ? 
+                {marginLeft: scrollbarWidth ? -scrollbarWidth : 0} :
+                {marginRight: scrollbarWidth ? -scrollbarWidth : 0}
+            ),
             marginBottom: scrollbarWidth ? -scrollbarWidth : 0,
             ...(autoHeight && {
                 ...viewStyleAutoHeight,

--- a/src/Scrollbars/styles.js
+++ b/src/Scrollbars/styles.js
@@ -35,6 +35,12 @@ export const viewStyleUniversalInitial = {
     marginBottom: 0,
 };
 
+export const viewStyleRtlUniversalInitial = {
+    ...viewStyleUniversalInitial,
+    marginRight: undefined,
+    marginLeft: 0,
+};
+
 export const trackHorizontalStyleDefault = {
     position: 'absolute',
     height: 6


### PR DESCRIPTION
fixes #69 .

This only removes the native scroller on the left side that is shown alongside the custom scroller.

It is OK to have the scroller on the right side with RTL language. yet if I will see that there is a demand to have the scroller on the left I'll try to do some effort toward it. yet I don't think it is needed.