### PR TITLE
Add '-webkit-overflow-scrolling: touch;' to keep as same as where it is used

### DIFF
--- a/src/utils/getScrollbarWidth.js
+++ b/src/utils/getScrollbarWidth.js
@@ -12,7 +12,8 @@ export default function getScrollbarWidth() {
             position: 'absolute',
             top: -9999,
             overflow: 'scroll',
-            MsOverflowStyle: 'scrollbar'
+            MsOverflowStyle: 'scrollbar',
+            webkitOverflowScrolling: 'touch'
         });
         document.body.appendChild(div);
         scrollbarWidth = (div.offsetWidth - div.clientWidth);


### PR DESCRIPTION
Hi,
  When I use it in `ipad`, I find the content was obscured by the width of scrollbar。There is a style '-webkit-overflow-scrolling: touch;' where it is used, so its scrollbar width is 0. But when you compute the scrollbar width, this style is not added, so can you add it as this commit?