### PR TITLE
Support `mobile` prop to force mobile device use custom scrollbar

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -4,7 +4,7 @@ import { Component, createElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 
 import isString from '../utils/isString';
-import getScrollbarWidth from '../utils/getScrollbarWidth';
+import getScrollbarWidth, { isForcedMobile } from '../utils/getScrollbarWidth';
 import returnFalse from '../utils/returnFalse';
 import getInnerWidth from '../utils/getInnerWidth';
 import getInnerHeight from '../utils/getInnerHeight';
@@ -13,6 +13,7 @@ import {
     containerStyleDefault,
     containerStyleAutoHeight,
     viewStyleDefault,
+    viewStyleMobile,
     viewStyleAutoHeight,
     viewStyleUniversalInitial,
     trackHorizontalStyleDefault,
@@ -214,8 +215,9 @@ export default class Scrollbars extends Component {
         /* istanbul ignore if */
         if (typeof document === 'undefined' || !this.view) return;
         const { view, trackHorizontal, trackVertical, thumbHorizontal, thumbVertical } = this;
+        const { mobile } = this.props;
         view.addEventListener('scroll', this.handleScroll);
-        if (!getScrollbarWidth()) return;
+        if (!getScrollbarWidth(mobile)) return;
         trackHorizontal.addEventListener('mouseenter', this.handleTrackMouseEnter);
         trackHorizontal.addEventListener('mouseleave', this.handleTrackMouseLeave);
         trackHorizontal.addEventListener('mousedown', this.handleHorizontalTrackMouseDown);
@@ -231,8 +233,9 @@ export default class Scrollbars extends Component {
         /* istanbul ignore if */
         if (typeof document === 'undefined' || !this.view) return;
         const { view, trackHorizontal, trackVertical, thumbHorizontal, thumbVertical } = this;
+        const { mobile } = this.props;
         view.removeEventListener('scroll', this.handleScroll);
-        if (!getScrollbarWidth()) return;
+        if (!getScrollbarWidth(mobile)) return;
         trackHorizontal.removeEventListener('mouseenter', this.handleTrackMouseEnter);
         trackHorizontal.removeEventListener('mouseleave', this.handleTrackMouseLeave);
         trackHorizontal.removeEventListener('mousedown', this.handleHorizontalTrackMouseDown);
@@ -444,9 +447,9 @@ export default class Scrollbars extends Component {
     }
 
     _update(callback) {
-        const { onUpdate, hideTracksWhenNotNeeded } = this.props;
+        const { onUpdate, hideTracksWhenNotNeeded, mobile } = this.props;
         const values = this.getValues();
-        if (getScrollbarWidth()) {
+        if (getScrollbarWidth(mobile)) {
             const { scrollLeft, clientWidth, scrollWidth } = values;
             const trackHorizontalWidth = getInnerWidth(this.trackHorizontal);
             const thumbHorizontalWidth = this.getThumbHorizontalWidth();
@@ -482,7 +485,6 @@ export default class Scrollbars extends Component {
     }
 
     render() {
-        const scrollbarWidth = getScrollbarWidth();
         /* eslint-disable no-unused-vars */
         const {
             onScroll,
@@ -508,9 +510,11 @@ export default class Scrollbars extends Component {
             autoHeightMax,
             style,
             children,
+            mobile,
             ...props
         } = this.props;
         /* eslint-enable no-unused-vars */
+        const scrollbarWidth = getScrollbarWidth(mobile);
 
         const { didMountUniversal } = this.state;
 
@@ -524,8 +528,10 @@ export default class Scrollbars extends Component {
             ...style
         };
 
+        const baseViewStyle = isForcedMobile(mobile) ? viewStyleMobile : viewStyleDefault;
+
         const viewStyle = {
-            ...viewStyleDefault,
+            ...baseViewStyle,
             // Hide scrollbars by setting a negative margin
             marginRight: scrollbarWidth ? -scrollbarWidth : 0,
             marginBottom: scrollbarWidth ? -scrollbarWidth : 0,
@@ -625,6 +631,7 @@ Scrollbars.propTypes = {
     universal: PropTypes.bool,
     style: PropTypes.object,
     children: PropTypes.node,
+    mobile: PropTypes.bool,
 };
 
 Scrollbars.defaultProps = {
@@ -643,4 +650,5 @@ Scrollbars.defaultProps = {
     autoHeightMin: 0,
     autoHeightMax: 200,
     universal: false,
+    mobile: false
 };

--- a/src/Scrollbars/styles.js
+++ b/src/Scrollbars/styles.js
@@ -1,3 +1,5 @@
+import { MOBILE_SCROLLBAR_WIDTH } from '../utils/getScrollbarWidth';
+
 export const containerStyleDefault = {
     position: 'relative',
     overflow: 'hidden',
@@ -16,6 +18,18 @@ export const viewStyleDefault = {
     left: 0,
     right: 0,
     bottom: 0,
+    overflow: 'scroll',
+    WebkitOverflowScrolling: 'touch'
+};
+
+export const viewStyleMobile = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingRight: `${MOBILE_SCROLLBAR_WIDTH}px`,
+    paddingBottom: `${MOBILE_SCROLLBAR_WIDTH}px`,
     overflow: 'scroll',
     WebkitOverflowScrolling: 'touch'
 };

--- a/src/utils/getScrollbarWidth.js
+++ b/src/utils/getScrollbarWidth.js
@@ -1,8 +1,10 @@
 import css from 'dom-css';
 let scrollbarWidth = false;
 
-export default function getScrollbarWidth() {
-    if (scrollbarWidth !== false) return scrollbarWidth;
+export const MOBILE_SCROLLBAR_WIDTH = 12;
+
+const getScrollbarWidth = (forceMobile) => {
+    if (scrollbarWidth !== false) return scrollbarWidth || (forceMobile ? MOBILE_SCROLLBAR_WIDTH : 0);
     /* istanbul ignore else */
     if (typeof document !== 'undefined') {
         const div = document.createElement('div');
@@ -20,5 +22,10 @@ export default function getScrollbarWidth() {
     } else {
         scrollbarWidth = 0;
     }
-    return scrollbarWidth || 0;
-}
+
+    return scrollbarWidth || (forceMobile ? MOBILE_SCROLLBAR_WIDTH : 0);
+};
+
+export const isForcedMobile = (forceMobile) => forceMobile && getScrollbarWidth();
+
+export default getScrollbarWidth;

--- a/test/Scrollbars/index.js
+++ b/test/Scrollbars/index.js
@@ -9,6 +9,7 @@ import autoHide from './autoHide';
 import autoHeight from './autoHeight';
 import hideTracks from './hideTracks';
 import universal from './universal';
+import mobile from './mobile';
 import onUpdate from './onUpdate';
 
 export default function createTests(scrollbarWidth, envScrollbarWidth) {
@@ -23,5 +24,6 @@ export default function createTests(scrollbarWidth, envScrollbarWidth) {
     autoHeight(scrollbarWidth, envScrollbarWidth);
     hideTracks(scrollbarWidth, envScrollbarWidth);
     universal(scrollbarWidth, envScrollbarWidth);
+    mobile(scrollbarWidth, envScrollbarWidth);
     onUpdate(scrollbarWidth, envScrollbarWidth);
 }

--- a/test/Scrollbars/mobile.js
+++ b/test/Scrollbars/mobile.js
@@ -1,0 +1,34 @@
+import { Scrollbars } from 'react-custom-scrollbars';
+import { render, unmountComponentAtNode } from 'react-dom';
+import React from 'react';
+import { MOBILE_SCROLLBAR_WIDTH as scrollbarWidth } from '../../src/utils/getScrollbarWidth';
+export default function createTests(envScrollbarWidth) {
+    let node;
+    beforeEach(() => {
+        node = document.createElement('div');
+        document.body.appendChild(node);
+    });
+    afterEach(() => {
+        unmountComponentAtNode(node);
+        document.body.removeChild(node);
+    });
+
+    describe('mobile', () => {
+        if (envScrollbarWidth) return;
+        it('should render scrollbar', done => {
+            render((
+                <Scrollbars mobile style={{ width: 100, height: 100 }}>
+                    <div style={{ width: 200, height: 200 }}/>
+                </Scrollbars>
+            ), node, function callback() {
+                setTimeout(() => {
+                    const { view } = this;
+                    expect(view.style.overflow).toEqual('scroll');
+                    expect(view.style.marginBottom).toEqual(`${-scrollbarWidth}px`);
+                    expect(view.style.marginRight).toEqual(`${-scrollbarWidth}px`);
+                    done();
+                }, 100);
+            });
+        });
+    });
+}

--- a/test/mobile.spec.js
+++ b/test/mobile.spec.js
@@ -1,5 +1,6 @@
 const getScrollbarWidthModule = require('../src/utils/getScrollbarWidth');
 const envScrollbarWidth = getScrollbarWidthModule.default();
+import { MOBILE_SCROLLBAR_WIDTH } from '../src/utils/getScrollbarWidth';
 import createTests from './Scrollbars';
 
 describe('Scrollbars (mobile)', () => {
@@ -8,7 +9,7 @@ describe('Scrollbars (mobile)', () => {
 
     before(() => {
         getScrollbarWidthSpy = spyOn(getScrollbarWidthModule, 'default');
-        getScrollbarWidthSpy.andReturn(mobileScrollbarsWidth);
+        getScrollbarWidthSpy.andCall(forceMobile => (forceMobile ? MOBILE_SCROLLBAR_WIDTH : mobileScrollbarsWidth));
     });
 
     after(() => {


### PR DESCRIPTION
This PR adds a new attribute `mobile`, which force mobile device use the custom scrollbar.
(mobile means the native scrollbar width is 0)

ref: #299