### PR TITLE
fix: init height and width error

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -452,7 +452,7 @@ export default class Scrollbars extends Component {
             const thumbHorizontalWidth = this.getThumbHorizontalWidth();
             const thumbHorizontalX = scrollLeft / (scrollWidth - clientWidth) * (trackHorizontalWidth - thumbHorizontalWidth);
             const thumbHorizontalStyle = {
-                width: thumbHorizontalWidth,
+                width: thumbHorizontalWidth || 0,
                 transform: `translateX(${thumbHorizontalX}px)`
             };
             const { scrollTop, clientHeight, scrollHeight } = values;
@@ -460,7 +460,7 @@ export default class Scrollbars extends Component {
             const thumbVerticalHeight = this.getThumbVerticalHeight();
             const thumbVerticalY = scrollTop / (scrollHeight - clientHeight) * (trackVerticalHeight - thumbVerticalHeight);
             const thumbVerticalStyle = {
-                height: thumbVerticalHeight,
+                height: thumbVerticalHeight || 0,
                 transform: `translateY(${thumbVerticalY}px)`
             };
             if (hideTracksWhenNotNeeded) {


### PR DESCRIPTION
in [_update ](https://github.com/malte-wessel/react-custom-scrollbars/blob/b353cc4956d6154d6a100f34c3a6202c75434186/src/Scrollbars/index.js#L446) function， `getThumbHorizontalWidth` and `getThumbVerticalHeight` will return `NaN` sometimes, cause an unnecessary thumb. like this..

![image](https://user-images.githubusercontent.com/9245399/69115819-03fd7a00-0ac5-11ea-8232-244efb9c3d80.png)
